### PR TITLE
fix: alignment of contact page as compared to other pages

### DIFF
--- a/src/pages/contact.jsx
+++ b/src/pages/contact.jsx
@@ -61,7 +61,7 @@ const Contact = () => {
 						</div>
 					</div>
 
-					<div className="contact-container">
+					<div className="socials-container">
 						<div className="contact-socials">
 							<Socials />
 						</div>

--- a/src/pages/styles/contact.css
+++ b/src/pages/styles/contact.css
@@ -20,14 +20,19 @@
 .contact-container {
 	display: flex;
 	flex-direction: column;
-	height: 100%;
-	margin: 0;
-	padding-top: 120px;
+	justify-content: space-around;
+	margin-top: 120px;
+}
+
+
+.socials-container {
+	display: flex;
+	flex-direction: column;
+	margin-top: 80px;
 }
 
 .contact-socials {
 	display: flex;
 	justify-content: flex-start;
 	align-items: center;
-	margin-top: -70px;
 }


### PR DESCRIPTION
This PR fixes the alignment issue that is seen between contact and other pages, as shown in the video, the page slides to the left when contact page is opened


https://github.com/truethari/reactfolio/assets/43206820/05182c13-3f55-4e69-ab7f-a7af1c8f0d47


 
